### PR TITLE
[CV-2176]Caffe::InnerProduct layer supports vector bias term

### DIFF
--- a/onnx_caffe/_operators.py
+++ b/onnx_caffe/_operators.py
@@ -294,8 +294,9 @@ def _convert_gemm(node, graph, err):
     if len(node.inputs) > 2:
         b = node.input_tensors[node.inputs[2]]
 
-    if len(W.shape) != 2 or (b is not None and any(b!=0)):
+    if len(W.shape) != 2:
         return err.unsupported_op_configuration(node, "Gemm is supported only for inner_product layer" + "b.shape=" + str(b.shape) + ' ss=' + str((b*b).sum()))
+
     if b is not None and any(b!=0):
         bias_flag = True
         if W.shape[0] != b.shape[0]:

--- a/onnx_caffe/_operators.py
+++ b/onnx_caffe/_operators.py
@@ -294,8 +294,8 @@ def _convert_gemm(node, graph, err):
     if len(node.inputs) > 2:
         b = node.input_tensors[node.inputs[2]]
 
-    if len(W.shape) != 2 or (b is not None and b.size != 1):
-        return err.unsupported_op_configuration(node, "Gemm is supported only for inner_product layer")
+    if len(W.shape) != 2 or (b is not None and any(b!=0)):
+        return err.unsupported_op_configuration(node, "Gemm is supported only for inner_product layer" + "b.shape=" + str(b.shape) + ' ss=' + str((b*b).sum()))
     if b is not None and any(b!=0):
         bias_flag = True
         if W.shape[0] != b.shape[0]:

--- a/onnx_caffe/_weightloader.py
+++ b/onnx_caffe/_weightloader.py
@@ -91,18 +91,21 @@ def _convert_gemm(net, node, graph, err):
     else:
         err.missing_initializer(node,
                                 "Weight tensor: {} not found in the graph initializer".format(weight_name, ))
+    net.params[node_name][0].data[...] = W
+
     if node.attrs.get("broadcast", 1) != 1 or node.attrs["transB"] != 1:
         return err.unsupported_op_configuration(node, "Gemm is supported only for inner_product layer")
     b = None
     if len(node.inputs) > 2:
         b = node.input_tensors[node.inputs[2]]
-    if len(W.shape) != 2 or any(b!=0):
+
+    if len(W.shape) != 2:
         return err.unsupported_op_configuration(node, "Gemm is supported only for inner_product layer")
+
     if b is not None and any(b!=0):
         if W.shape[0] != b.shape[0]:
             return err.unsupported_op_configuration(node, "Gemm is supported only for inner_product layer")
-    net.params[node_name][0].data[...] = W
-    #net.params[node_name][1].data[...] = b
+        net.params[node_name][1].data[...] = b
 
 
 def _convert_upsample(net, node, graph, err):

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,8 @@ class TestCommand(test):
         import shlex
         # import here, cause outside the eggs aren't loaded
         import pytest
-        run_script('pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp36-cp36m-linux_x86_64.whl')
+        run_script('pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+')
         run_script('pip install git+https://github.com/onnx/onnx.git')
         run_script('pip install torchvision')
         errno = pytest.main(shlex.split(self.pytest_args))

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ class CMakeBuild(build_ext):
         subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp, shell=False)
         
         import shutil
+        shutil.rmtree(os.path.join(extdir, 'caffe'), ignore_errors=True)
         shutil.copytree(os.path.join(self.build_temp, 'python', 'caffe'), os.path.join(extdir, 'caffe'))
 
 
@@ -82,9 +83,9 @@ class TestCommand(test):
         import shlex
         # import here, cause outside the eggs aren't loaded
         import pytest
-        run_script('pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html')
+        run_script('pip install torch-nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html')
         run_script('pip install git+https://github.com/onnx/onnx.git')
-        run_script('pip install torchvision')
+        run_script('pip install torchvision-nightly')
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,7 @@ class TestCommand(test):
         import shlex
         # import here, cause outside the eggs aren't loaded
         import pytest
-        run_script('pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-')
+        run_script('pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html')
         run_script('pip install git+https://github.com/onnx/onnx.git')
         run_script('pip install torchvision')
         errno = pytest.main(shlex.split(self.pytest_args))


### PR DESCRIPTION
[Why] ResNet conversion failed at GEMM layer. The original conversion code supported scalar bias
[How] Add support for vector bias
[What]
* migrate to pytorch 1.0 (torchvision-, torch- nightly)
* check bias shape: accepts scalar, vector but not matrix 